### PR TITLE
Edit execution story in major_event.dart and add method

### DIFF
--- a/lib/justice/prison.dart
+++ b/lib/justice/prison.dart
@@ -53,7 +53,8 @@ Future<void> prison(Creature g) async {
     "lethal injection",
     "hanging",
     "firing squad",
-    "electrocution"
+    "electrocution",
+    "inert gas asphyxiation"
   ];
 
   const List<String> supposedlyHumaneExecutionMethods = ["lethal injection"];

--- a/lib/newspaper/major_event.dart
+++ b/lib/newspaper/major_event.dart
@@ -418,6 +418,19 @@ String majorEventStoryText(View? view, bool positive) {
         String timeOfDeath =
             "${lcsRandom(12) + 1}:${lcsRandom(6)}${lcsRandom(10)} ${oneIn(2) ? "AM" : "PM"}";
         int yearConvicted = year - lcsRandom(11) - 10;
+        String byExecutionMethod = switch (laws[Law.deathPenalty]) {
+          DeepAlignment.archConservative => [
+              "on the cross",
+              "in a fire ant nest",
+              "in a sewage digester vat",
+              "in the guillotine",
+            ].random;
+          DeepAlignment.Conservative => [
+              "in the gallows",
+              "in the electric chair",
+            ].random;
+           _ => "by lethal injection",
+        };
         String exculpatoryEvidence = [
           "a confession from another convict",
           "a battery of negative DNA tests",
@@ -430,7 +443,7 @@ String majorEventStoryText(View? view, bool positive) {
         ].random;
 
         story = "${randomStateName()} - An innocent citizen has been put "
-            "to death in the electric chair.  "
+            "to death $byExecutionMethod.  "
             "$victim was pronounced dead at $timeOfDeath yesterday at the "
             "${lastName()} Correctional Facility.&r"
             "  ${victim.last} was convicted in $yearConvicted of 13 "


### PR DESCRIPTION
Currently, the news will say someone was executed by electric chair regardless of whether the Death Penalty law is C+ or L, which is a contradiction, since the electric chair is only available at C.

(Also, you may have heard of the man executed by nitrogen gas - more "experimental" than "historic", but I think it fits with C.)