### PR TITLE
minor UI tweaks for creature_info + dating/recruiting

### DIFF
--- a/lib/common_display/print_creature_info.dart
+++ b/lib/common_display/print_creature_info.dart
@@ -467,16 +467,23 @@ void printFullCreatureStats(Creature cr,
     }
   }
 
+  // Add task
+  mvaddstrc(12, 0, lightGray, "Task: ");
+  setColor(cr.activity.color);
+  addparagraph(12, 6, cr.activity.description, y2: 14, x2: 26);
+  setColor(lightGray);
+  // addstrc(cr.activity.color, cr.activity.description);
+
   // Add weapon
-  mvaddstrc(13, 0, lightGray, "Weapon: ");
+  mvaddstrc(console.y, 0, lightGray, "Weapon: ");
   printWeapon(cr);
 
   // Add clothing
-  mvaddstrc(14, 0, lightGray, "Clothes: ");
+  mvaddstrc(console.y+1, 0, lightGray, "Clothes: ");
   cr.clothing.printEquipTitle(full: true, armor: false);
 
   // Add vehicle
-  mvaddstrc(15, 0, lightGray, "Car: ");
+  mvaddstrc(console.y+1, 0, lightGray, "Car: ");
   Vehicle? v;
   if (showCarPrefs == ShowCarPrefs.showPreferences) {
     v = cr.preferredCar;
@@ -505,23 +512,23 @@ void printFullCreatureStats(Creature cr,
 
   // Add recruit stats
   if (!cr.brainwashed) {
-    move(18, 0);
+    move(19, 0);
     addstr((cr.maxSubordinates - cr.subordinatesLeft).toString());
     addstr(" Recruits / ");
     addstr(cr.maxSubordinates.toString());
     addstr(" Max");
   } else {
-    move(18, 0);
+    move(19, 0);
     addstr("Enlightened Can't Recruit");
   }
   // Any meetings with potential recruits scheduled?
   if (cr.scheduledMeetings > 0) {
-    move(18, 55);
+    move(19, 55);
     addstr("Scheduled Meetings: ");
     addstr(cr.scheduledMeetings.toString());
   }
   // Add seduction stats
-  move(19, 0);
+  move(20, 0);
   int lovers = cr.relationships.length;
   int maxLovers = cr.maxRelationships;
   addstr("$lovers Lover");
@@ -529,7 +536,7 @@ void printFullCreatureStats(Creature cr,
   addstr(" / $maxLovers Max");
   // Any dates with potential love interests scheduled?
   if (cr.scheduldeDates > 0) {
-    move(19, 55);
+    move(20, 55);
     addstr("Scheduled Dates:    ");
     addstr(cr.scheduldeDates.toString());
   }

--- a/lib/daily/dating.dart
+++ b/lib/daily/dating.dart
@@ -120,7 +120,7 @@ Future<bool> completeDate(DatingSession d, Creature p) async {
   erase();
   setColor(white);
   move(0, 0);
-  String message = "${p.name} has ";
+  String message = "&W${p.name} &whas ";
   if (d.dates.length == 1) {
     if (p.clinicMonthsLeft > 0 || city == null) {
       message += "a \"hot\" date with ";
@@ -132,19 +132,19 @@ Future<bool> completeDate(DatingSession d, Creature p) async {
   }
   for (int ei = 0; ei < d.dates.length; ei++) {
     Creature e = d.dates[ei];
-    message += e.name;
+    message += "&W${e.name}";
 
     if (ei <= d.dates.length - 3) {
-      message += ", ";
+      message += "&w, ";
     } else if (ei == d.dates.length - 2) {
-      message += " and ";
+      message += "&w and ";
     } else {
       if (p.clinicMonthsLeft > 0) {
-        message += " at ${p.location?.name}";
+        message += "&w at &W${p.location?.name}";
       } else if (city == null) {
-        message += " over video chat";
+        message += "&w over video chat";
       }
-      message += ".";
+      message += "&w.";
     }
   }
   addparagraph(1, 1, x2: console.width - 2, message);
@@ -271,7 +271,9 @@ Future<bool> completeDate(DatingSession d, Creature p) async {
       temp.removeAt(temp.length - 1);
     }
 
-    mvaddstr(10, 0, "How should ${p.name} approach the situation?");
+    mvaddstr(10, 0, "How should ");
+    addstrc(white, p.name);
+    addstrc(lightGray, " approach the situation?");
 
     bool canPay100 = ledger.funds >= 100 &&
         p.clinicMonthsLeft == 0 &&

--- a/lib/daily/recruitment.dart
+++ b/lib/daily/recruitment.dart
@@ -185,7 +185,9 @@ Future<bool> completeRecruitMeeting(RecruitmentSession r, Creature p) async {
         addstr(" kind of regrets agreeing to this.");
       }
   }
-  mvaddstr(11, 0, "How should ${p.name} approach the situation?");
+  mvaddstr(11, 0, "How should ");
+  addstrc(white, p.name);
+  addstrc(lightGray, " approach the situation?");
 
   addOptionText(13, 0, "A",
       "A - Spend \$50 on props and a${inPerson ? " " : "n e-"}book for them to keep.",

--- a/lib/talk/talk_outside_combat.dart
+++ b/lib/talk/talk_outside_combat.dart
@@ -28,7 +28,8 @@ Future<bool> talkOutsideCombat(Creature a, Creature tk) async {
   bool nude = a.indecent;
   String whileNaked = nude ? " while naked" : "";
   clearSceneAreas();
-  mvaddstrc(9, 1, white, "${a.name} talks to ");
+  mvaddstrc(9, 1, white, a.name);
+  addstrc(lightGray, " talks to ");
   addstrc(tk.align.color, tk.name);
   setColor(white);
   printCreatureAgeAndGender(tk);


### PR DESCRIPTION
adds current activity to creature info screen, and uses white/lightGray in dating+recruitment screens to highlight current speaker. 

my git is rusty, so forgot to create separate branches for separate pull requests, sorry. If you're willing to take PR's like these, I'll try and be more granular in the future! 